### PR TITLE
find_updates: return in ALL the appropriate failure cases

### DIFF
--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -67,8 +67,14 @@ def check_version(bot):
     except ValueError:
         # TODO: use JSONDecodeError when dropping Pythons < 3.5
         _check_failed(bot)
+        success = False
 
-    if not success and bot.memory.get('update_failures', 0) > 4:
+    if not success:
+        if bot.memory.get('update_failures', 0) <= 4:
+            # not enough failures to worry; silently ignore this one
+            return
+
+        # too many failures to ignore; notify owner
         bot.say(
             "[update] I haven't been able to check for updates in a while. "
             "Please verify that {} is working and I can reach it."


### PR DESCRIPTION
Even if there haven't been enough check failures to trigger a warning to
Sopel's owner, it still needs to skip trying to print the `info` about
whatever new release is available because that variable doesn't exist.

Fixes #2051.

Missed in #1779 / 951fccaccf5f4bdb70058a326543c1d82354c453, oops.

### Description
What does this do? What problem does it solve? Does it resolve any GitHub issues?

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
